### PR TITLE
cached data for faster requests from the front-end

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,12 @@
 import express from "express";
 import * as superagent from "superagent";
 import cors from "cors";
+import * as _ from "lodash";
+import NodeCache from "node-cache";
 
+interface cache {
+  data: string;
+}
 const app: express.Application = express();
 const port = process.env.PORT || 4000;
 
@@ -9,14 +14,33 @@ app.use(cors());
 app.use(express.json());
 
 const API_KEY: string = "659d5c6b8f3d2447f090119e48202fdb";
+const myCache = new NodeCache();
 
 app.get(
   "/breweries",
-  async (request: express.Request, response: express.Response) => {
-    const apiResponse = await superagent.get(
-      `https://sandbox-api.brewerydb.com/v2/breweries/?withLocations=Y&key=${API_KEY}`
-    );
-    response.status(200).json(apiResponse.body);
+  async (
+    request: express.Request,
+    response: express.Response,
+    next: express.NextFunction
+  ) => {
+    try {
+      if (myCache.has("breweries")) {
+        const cachedData: cache | undefined = myCache.get("breweries");
+        if (typeof cachedData === "object") {
+          const parsedData: object = JSON.parse(cachedData.data);
+          response.status(200).json(parsedData);
+        }
+      } else {
+        const apiResponse = await superagent.get(
+          `https://sandbox-api.brewerydb.com/v2/breweries/?withLocations=Y&key=${API_KEY}`
+        );
+        const stringifed = { data: JSON.stringify(apiResponse.body) };
+        response.status(200).json(apiResponse.body);
+        myCache.set("breweries", stringifed, 10000);
+      }
+    } catch (error) {
+      next(error);
+    }
   }
 );
 

--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
   "dependencies": {
     "@types/cors": "^2.8.6",
     "@types/express": "^4.17.5",
+    "@types/lodash": "^4.14.149",
     "@types/node": "^13.11.0",
     "@types/superagent": "^4.1.7",
     "cors": "^2.8.5",
     "eslint": "^6.8.0",
     "eslint-plugin-import": "^2.20.2",
     "express": "^4.17.1",
+    "lodash": "^4.17.15",
+    "node-cache": "^5.1.0",
     "superagent": "^5.2.2",
     "ts-node": "^8.8.2",
     "typescript": "^3.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,6 +73,11 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/lodash@^4.14.149":
+  version "4.14.149"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
+  integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
+
 "@types/mime@*":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
@@ -290,6 +295,11 @@ cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
   integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
+
+clone@2.x:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -1176,6 +1186,13 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-cache@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.0.tgz#266786c28dcec0fd34385ee29c383e6d6f1aa5de"
+  integrity sha512-gFQwYdoOztBuPlwg6DKQEf50G+gkK69aqLnw4djkmlHCzeVrLJfwvg9xl4RCAGviTIMUVoqcyoZ/V/wPEu/VVg==
+  dependencies:
+    clone "2.x"
 
 normalize-package-data@^2.3.2:
   version "2.5.0"


### PR DESCRIPTION
Used Node-Cache to cache the data and shorten the HTTP request time in the front-end. Due to the cache size limit, the API response was stringified using JSON when storing in the cache and parsed with JSON after retrieving from the cache and before sending a response.  